### PR TITLE
fix: add missing meta.json

### DIFF
--- a/src/blocks/kwiczling2/meta.json
+++ b/src/blocks/kwiczling2/meta.json
@@ -1,0 +1,6 @@
+
+{
+    "block_name": "Responsive Header",
+    "author_name": "K-Wiczling",
+    "author_github_url": "https://github.com/K-Wiczling/"
+  }


### PR DESCRIPTION
# Zero To Mastery - Webblocks 2022 📦📦

## PR contains:
- fix workflow run by adding missing `meta.json` file

## Breaking changes
- None

## Screenshots
- None